### PR TITLE
Remove unused requires

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -1,7 +1,4 @@
-fs = require 'fs'
-path = require 'path'
 _ = require 'lodash'
-child_process = require 'child_process'
 uuid = require 'uuid'
 jmp = require 'jmp'
 EventEmitter = require('eventemitter2').EventEmitter2


### PR DESCRIPTION
In reading through, I noticed `child_process`, `fs`, and `path` weren't being used so I removed the `require`s.